### PR TITLE
Add flake-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,25 @@ nix flake that provides https://github.com/samm-git/aws-vpn-client/pull/16
 
 ```nix
 {
-  inputs = {
-    awsvpnclient.url = "github:ymatsiuk/awsvpnclient";
-  };
-
-  outputs = {self, nixpkgs, awsvpnclient }:
-  {
-    nixosConfigurations.nixps = nixpkgs.lib.nixosSystem {
-      # ...
-      modules = [
-        {
-          nix.extraOptions = "experimental-features = nix-command flakes";
-          nix.package = pkgs.nixUnstable;
-          nixpkgs.overlays = [ awsvpnclient.overlay ];
-        }
+  inputs.awsvpnclient.url = "github:ymatsiuk/awsvpnclient";
+  outputs = { self, nixpkgs, awsvpnclient }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      nixosConfigurations.nixps = nixpkgs.lib.nixosSystem {
+        # ...
+        modules = [{ environment.systemPackages = [ awsvpnclient ]; }];
+        # ...
+      };
+      overlays = [
+        (final: prev: {
+          awsvpnclient = awsvpnclient.packages.${system}.awsvpnclient;
+        })
       ];
     };
- };
 }
 ```
-
-You can find a slightly more sophisticated example in [my flake](https://github.com/ymatsiuk/nixos-config/blob/8dca28ee74bfe18b7bc1c55feb1d5df2ade6008f/flake.nix#L64)
 
 ### Using the client
 

--- a/awsvpnclient.nix
+++ b/awsvpnclient.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , makeWrapper
 , openvpn
-, sudo
 , xdg-utils
 }:
 
@@ -27,11 +26,11 @@ buildGoModule rec {
 
     substituteInPlace $out/awsvpnclient.yml \
       --replace /home/myname/aws-vpn-client/openvpn "openvpn" \
-      --replace /usr/bin/sudo "/run/wrappers/bin/sudo"
+      --replace /usr/bin/sudo "sudo"
 
     makeWrapper $out/bin/aws-vpn-client $out/bin/awsvpnclient \
       --run "cd $out" \
-      --prefix PATH : "${lib.makeBinPath [ openvpn xdg-utils sudo ]}"
+      --prefix PATH : "${lib.makeBinPath [ openvpn xdg-utils ]}"
   '';
 
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "narHash": "sha256-8nQx02tTzgYO21BP/dy5BCRopE8OwE8Drsw98j+Qoaw=",
@@ -13,6 +28,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,24 +1,18 @@
 {
   description = "AWS VPN client";
 
-  outputs = { self, nixpkgs }: {
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
-    packages.x86_64-linux = {
-      awsvpnclient = nixpkgs.legacyPackages.x86_64-linux.callPackage ./awsvpnclient.nix {
-        openvpn = nixpkgs.legacyPackages.x86_64-linux.callPackage ./openvpn.nix { };
-      };
-    };
-
-    defaultPackage.x86_64-linux = (import nixpkgs {
-      system = "x86_64-linux";
-      overlays = [ self.overlay ];
-    }).awsvpnclient;
-
-    overlay = final: prev: {
-      awsvpnclient = final.callPackage ./awsvpnclient.nix {
-        openvpn = final.callPackage ./openvpn.nix { };
-      };
-    };
-
-  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      rec {
+        packages = flake-utils.lib.flattenTree {
+          awsvpnclient = pkgs.callPackage ./awsvpnclient.nix {
+            openvpn = pkgs.callPackage ./openvpn.nix { };
+          };
+        };
+        defaultPackage = packages.awsvpnclient;
+      }
+    );
 }


### PR DESCRIPTION
- Add support for architectures other than `x86_64-linux`
- Drop overlay and use a regular package instead

TODO: Update readme